### PR TITLE
Target Frameworks Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The target source name from the pull request
 
 Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`
 
+### `target_frameworks`
+
+**Optional**: The target frameworks on which the tests will run. **(default is `net6.0`)**
+
+Possible values are available [here](https://learn.microsoft.com/en-us/dotnet/standard/frameworks).
+
 ## Usage
 
 Using for push on long-lived branches:

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: "Verbosity level for dotnet test command"
     required: false
     default: m
+  target_frameworks:
+    description: "The target framework on which tests will run (if multiple are installed)"
+    required: false
+    default: net6.0
 runs:
   using: composite
   steps:
@@ -182,6 +186,7 @@ runs:
       env:
         SOLUTION: ${{ inputs.solution }}
         VERBOSITY: ${{ inputs.verbosity }}
+        TARGET_FRAMEWORKS: ${{ inputs.target_frameworks }}
       run: |
         dotnet test $SOLUTION.sln \
         /p:CollectCoverage=true \
@@ -189,6 +194,7 @@ runs:
         /p:MergeWith=./results/*.opencover.xml \
         /p:CoverletOutput=./results/ \
         /p:CoverletOutputFormat=opencover \
+        /p:TargetFrameworks=$TARGET_FRAMEWORKS \
         --logger "GitHubActions;report-warnings=false" \
         --verbosity $VERBOSITY
 
@@ -198,6 +204,7 @@ runs:
       env:
         PROJECT: ${{ inputs.project }}
         VERBOSITY: ${{ inputs.verbosity }}
+        TARGET_FRAMEWORKS: ${{ inputs.target_frameworks }}
       run: |
         dotnet test $PROJECT \
         /p:CollectCoverage=true \
@@ -205,6 +212,7 @@ runs:
         /p:MergeWith=./results/*.opencover.xml \
         /p:CoverletOutput=./results/ \
         /p:CoverletOutputFormat=opencover \
+        /p:TargetFrameworks=$TARGET_FRAMEWORKS \
         --logger "GitHubActions;report-warnings=false" \
         --verbosity $VERBOSITY
 


### PR DESCRIPTION
Adding the possibility to specify the target frameworks on which the tests will run. The default is net6.0

Possible values are available [here](https://learn.microsoft.com/en-us/dotnet/standard/frameworks). 