### PR TITLE
FIX: v6 inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ The target source name from the pull request
 
 Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`
 
+### `enable-dotnet-restore`
+
+**Optional**: Runs `dotnet restore` before runs `dotnet test`. **(default is `false`)**
+
+### `enable-dotnet-build`
+
+**Optional**: Runs `dotnet build --no-restore` before runs `dotnet test`. **(default is `false`)**
+
+### `dotnet-test-flags`
+
+**Optional**: Add flags for `dotnet test` command. **(default is no flags)**.
+
+Full flags list is available [here](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test#synopsis).
+
 ## Usage
 
 Using for push on long-lived branches:
@@ -160,4 +174,22 @@ Using with multiline file code exclusions:
       src/Warren.Core.MyRepo.Services/**/*.cs
     pull-request: false
     branch-name: ${{ github.head_ref || github.ref_name }}
+```
+
+Using with dotnet restore, dotnet build and dotnet test flags:
+
+```yml
+- name: Warren - Run Tests and SonarQube Analysis
+  uses: warrenbrasil/sonar-qube@v3
+  with:
+    sonar-token: ${{ secrets.SONAR_TOKEN }}
+    sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+    sonar-project-key: myorg_my-project-key
+    sonar-organization: myorg
+    solution: Warren.Core.MyRepo
+    pull-request: false
+    branch-name: ${{ github.head_ref || github.ref_name }}
+    enable-dotnet-restore: true
+    enable-dotnet-build: true
+    dotnet-test-flags: --no-build --no-restore
 ```

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,18 @@ inputs:
     description: "Verbosity level for dotnet test command"
     required: false
     default: m
+  enable-dotnet-restore:
+    description: "Runs dotnet restore before dotnet test"
+    required: false
+    default: false
+  enable-dotnet-build:
+    description: "Runs dotnet build with no restore before dotnet test"
+    required: false
+    default: false
+  dotnet-test-flags:
+    description: "Flags for dotnet test command"
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -155,11 +167,13 @@ runs:
         /d:sonar.cs.opencover.reportsPaths="./$TESTS_DIR/**/results/*.opencover.xml"
 
     - name: Restore
+      if: ${{ inputs.enable-dotnet-restore == 'true' }}
       shell: bash
       run: |
         dotnet restore
 
     - name: Build
+      if: ${{ inputs.enable-dotnet-build == 'true' }}
       shell: bash
       run: |
         dotnet build --no-restore
@@ -170,6 +184,7 @@ runs:
       env:
         SOLUTION: ${{ inputs.solution }}
         VERBOSITY: ${{ inputs.verbosity }}
+        FLAGS: ${{ inputs.dotnet-test-flags }}
       run: |
         dotnet test $SOLUTION.sln \
         /p:CollectCoverage=true \
@@ -177,8 +192,7 @@ runs:
         /p:MergeWith=./results/*.opencover.xml \
         /p:CoverletOutput=./results/ \
         /p:CoverletOutputFormat=opencover \
-        --no-build --no-restore \
-        --logger "GitHubActions;report-warnings=false" \
+        $FLAGS --logger "GitHubActions;report-warnings=false" \
         --verbosity $VERBOSITY
 
     - name: Run tests
@@ -187,6 +201,7 @@ runs:
       env:
         PROJECT: ${{ inputs.project }}
         VERBOSITY: ${{ inputs.verbosity }}
+        FLAGS: ${{ inputs.dotnet-test-flags }}
       run: |
         dotnet test $PROJECT \
         /p:CollectCoverage=true \
@@ -194,8 +209,7 @@ runs:
         /p:MergeWith=./results/*.opencover.xml \
         /p:CoverletOutput=./results/ \
         /p:CoverletOutputFormat=opencover \
-        --no-build --no-restore \
-        --logger "GitHubActions;report-warnings=false" \
+        $FLAGS --logger "GitHubActions;report-warnings=false" \
         --verbosity $VERBOSITY
 
     - name: End Sonar Scan

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ inputs:
     required: false
     default: false
   dotnet-test-flags:
-    description: "Flags for dotnet test command"
+    description: "Add flags for dotnet test command"
     required: false
     default: ""
 runs:


### PR DESCRIPTION
# Version 6 fix

- [x] dotnet restore is disabled by default. can be enabled by using `enable-dotnet-restore: true` as input
- [x] dotnet build is disabled by default. can be enabled by using `enable-dotnet-build: true` as input
- [x] adding support to action consumer use `dotnet test` flags. available flags [here](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test#synopsis)