### PR TITLE
Version 7 - Installing JDK 17 for dotnet-sonarscanner 6.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: "microsoft"
+        java-version: "17"
+
     - name: Install SonarQube Scanner
       shell: bash
       run: dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
# Version 7

Installing `dotnet-sonarscanner` using the latest version will bring up JDK 11, but it requires the JDK 17. This fix will install the JDK 17 to ensure that sonar integration will work as expected without having to use previous versions of `dotnet-sonarscanner`.

## Screenshots

Without JDK 17:
![image](https://github.com/warrenbrasil/sonar-qube/assets/33238105/ebde3b24-5c80-4989-afce-9dd1dd5fede4)
With JDK 17:
![image](https://github.com/warrenbrasil/sonar-qube/assets/33238105/7e288219-6c7b-4834-bbae-8c94f4ae2df0)
